### PR TITLE
Update override status emojis

### DIFF
--- a/src/backend/telegram/menu.ts
+++ b/src/backend/telegram/menu.ts
@@ -7,23 +7,23 @@ import { toggleSetting, selectMode } from './settings'
 import { config } from '../config'
 
 export function createMenuTemplate() {
-        const menuTemplate = new MenuTemplate<Context>(() =>
-                [
-                        new Date().toLocaleString('en', {
-                                weekday: 'long',
-                                hour: 'numeric',
-                                minute: '2-digit',
-                                hour12: false,
-                        }),
-                        settings.nightOverride && '🚫🌙',
-                        settings.geoOverride && '🚫📍',
-                        dynamic.isAway && '📵',
-                        dynamic.isNight && '🌙',
-                        getIsWeekend() > 1 && '📅',
-                ]
-                        .filter(el => el)
-                        .join(' ')
-        )
+	const menuTemplate = new MenuTemplate<Context>(() =>
+		[
+			new Date().toLocaleString('en', {
+				weekday: 'long',
+				hour: 'numeric',
+				minute: '2-digit',
+				hour12: false,
+			}),
+			settings.nightOverride && '🌚',
+			settings.geoOverride && '🗺️',
+			dynamic.isAway && '📵',
+			dynamic.isNight && '🌙',
+			getIsWeekend() > 1 && '📅',
+		]
+			.filter(el => el)
+			.join(' ')
+	)
 
 	toggleSetting(menuTemplate, 'Night override', 'nightOverride')
 	toggleSetting(menuTemplate, 'GEO override', 'geoOverride')


### PR DESCRIPTION
## Summary
- shorten the override indicators to single emojis

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684733777f848330a6f6425a0889d952