### PR TITLE
Add plasma color mode

### DIFF
--- a/src/backend/pattern/index.ts
+++ b/src/backend/pattern/index.ts
@@ -4,6 +4,7 @@ import { IArrColor, IColorMapper, IMode } from 'src/typings'
 import { noiseFrameMapper } from './noise'
 import { getProgressColor } from './progress'
 import { getRainbowColor } from './rainbow'
+import { getPlasmaColor } from './plasma'
 import { createIndexedMapper, createFlatMapper } from './mappers'
 
 const mappers: Record<IMode, IColorMapper> = {
@@ -12,6 +13,7 @@ const mappers: Record<IMode, IColorMapper> = {
 	[IMode.Progress]: createIndexedMapper(getProgressColor),
 	[IMode.White]: createFlatMapper([255, 255, 255]),
 	[IMode.Noise]: noiseFrameMapper,
+	[IMode.Plasma]: createIndexedMapper(getPlasmaColor),
 	[IMode.Color]: createFlatMapper(() => settings.color),
 }
 

--- a/src/backend/pattern/plasma.ts
+++ b/src/backend/pattern/plasma.ts
@@ -1,0 +1,19 @@
+import { IColorGetter } from 'src/typings'
+import { hslToRgb } from 'src/helpers'
+import { pixelsCount, normalNoise } from '../shared'
+
+export const getPlasmaColor: IColorGetter = (index, time) => {
+	const x = index / pixelsCount
+	const t = time / 1000
+
+	const wave1 = Math.sin(t / 5 + x * 4)
+	const wave2 = Math.sin(t / 7 - x * 7)
+	const wave3 = Math.sin(t / 11 + x * 13)
+	const hueBase = (wave1 + wave2 + wave3) * 60
+	const hueNoise = normalNoise(t / 3, x) * 60
+	const hue = (hueBase + hueNoise + t * 10) % 360
+
+	const lightness = 0.5 + 0.1 * Math.sin(t / 3 + x * 2)
+
+	return hslToRgb(hue, 1, lightness)
+}

--- a/src/backend/telegram/settings.ts
+++ b/src/backend/telegram/settings.ts
@@ -28,6 +28,7 @@ export function selectMode(menuTemplate: MenuTemplate<Context>) {
 			[IMode.Progress]: 'progress',
 			[IMode.White]: 'white',
 			[IMode.Noise]: 'noise',
+			[IMode.Plasma]: 'plasma',
 			[IMode.Color]: 'color',
 		},
 		{

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -12,6 +12,7 @@ export enum IMode {
 	Progress,
 	White,
 	Noise,
+	Plasma,
 	Color,
 }
 


### PR DESCRIPTION
## Summary
- implement `getPlasmaColor` pattern
- hook up new plasma mapper
- expose plasma mode in bot settings
- extend `IMode` enum

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847363682b883309196a6d1b6865d86