### PR TITLE
Add smooth color modes

### DIFF
--- a/src/backend/pattern/breathe.ts
+++ b/src/backend/pattern/breathe.ts
@@ -1,0 +1,9 @@
+import { IColorGetter } from 'src/typings'
+import { hslToRgb } from 'src/helpers'
+
+export const getBreatheColor: IColorGetter = (_, time) => {
+	const t = time / 1000
+	const hue = (t * 20) % 360
+	const light = 0.5 + 0.25 * Math.sin(t / 2)
+	return hslToRgb(hue, 1, light)
+}

--- a/src/backend/pattern/fire.ts
+++ b/src/backend/pattern/fire.ts
@@ -1,0 +1,11 @@
+import { IColorGetter } from 'src/typings'
+import { hslToRgb } from 'src/helpers'
+import { pixelsCount, normalNoise } from '../shared'
+
+export const getFireColor: IColorGetter = (index, time) => {
+	const x = index / pixelsCount
+	const t = time / 1000
+	const hue = 20 + normalNoise(x * 3, t) * 20 + normalNoise(t, x) * 10
+	const light = 0.4 + normalNoise(x, t * 2) * 0.3
+	return hslToRgb(hue, 1, light)
+}

--- a/src/backend/pattern/index.ts
+++ b/src/backend/pattern/index.ts
@@ -4,6 +4,12 @@ import { IArrColor, IColorMapper, IMode } from 'src/typings'
 import { noiseFrameMapper } from './noise'
 import { getProgressColor } from './progress'
 import { getRainbowColor } from './rainbow'
+import { getPlasmaColor } from './plasma'
+import { getBreatheColor } from './breathe'
+import { getFireColor } from './fire'
+import { getOceanColor } from './ocean'
+import { getTwilightColor } from './twilight'
+import { getWaveColor } from './wave'
 import { createIndexedMapper, createFlatMapper } from './mappers'
 
 const mappers: Record<IMode, IColorMapper> = {
@@ -12,6 +18,12 @@ const mappers: Record<IMode, IColorMapper> = {
 	[IMode.Progress]: createIndexedMapper(getProgressColor),
 	[IMode.White]: createFlatMapper([255, 255, 255]),
 	[IMode.Noise]: noiseFrameMapper,
+	[IMode.Plasma]: createIndexedMapper(getPlasmaColor),
+	[IMode.Breathe]: createIndexedMapper(getBreatheColor),
+	[IMode.Fire]: createIndexedMapper(getFireColor),
+	[IMode.Ocean]: createIndexedMapper(getOceanColor),
+	[IMode.Twilight]: createIndexedMapper(getTwilightColor),
+	[IMode.Wave]: createIndexedMapper(getWaveColor),
 	[IMode.Color]: createFlatMapper(() => settings.color),
 }
 

--- a/src/backend/pattern/ocean.ts
+++ b/src/backend/pattern/ocean.ts
@@ -1,0 +1,12 @@
+import { IColorGetter } from 'src/typings'
+import { hslToRgb } from 'src/helpers'
+import { pixelsCount, normalNoise } from '../shared'
+
+export const getOceanColor: IColorGetter = (index, time) => {
+	const x = index / pixelsCount
+	const t = time / 1000
+	const wave = Math.sin(t / 6 + x * 3) + Math.sin(t / 8 - x * 5)
+	const hue = 190 + wave * 10 + normalNoise(x, t) * 5
+	const light = 0.5 + 0.1 * Math.sin(t / 4 + x * 2)
+	return hslToRgb(hue, 0.7, light)
+}

--- a/src/backend/pattern/plasma.ts
+++ b/src/backend/pattern/plasma.ts
@@ -1,0 +1,19 @@
+import { IColorGetter } from 'src/typings'
+import { hslToRgb } from 'src/helpers'
+import { pixelsCount, normalNoise } from '../shared'
+
+export const getPlasmaColor: IColorGetter = (index, time) => {
+	const x = index / pixelsCount
+	const t = time / 1000
+
+	const wave1 = Math.sin(t / 5 + x * 4)
+	const wave2 = Math.sin(t / 7 - x * 7)
+	const wave3 = Math.sin(t / 11 + x * 13)
+	const hueBase = (wave1 + wave2 + wave3) * 60
+	const hueNoise = normalNoise(t / 3, x) * 60
+	const hue = (hueBase + hueNoise + t * 10) % 360
+
+	const lightness = 0.5 + 0.1 * Math.sin(t / 3 + x * 2)
+
+	return hslToRgb(hue, 1, lightness)
+}

--- a/src/backend/pattern/twilight.ts
+++ b/src/backend/pattern/twilight.ts
@@ -1,0 +1,12 @@
+import { IColorGetter } from 'src/typings'
+import { hslToRgb } from 'src/helpers'
+import { pixelsCount } from '../shared'
+
+export const getTwilightColor: IColorGetter = (index, time) => {
+	const x = index / pixelsCount
+	const t = time / 1000
+	const hue = 260 + 20 * Math.sin(t / 5 + x)
+	const sat = 0.5 + 0.2 * Math.sin(t / 7)
+	const light = 0.3 + (0.2 * (Math.sin(t / 6 + x * 2) + 1)) / 2
+	return hslToRgb(hue, sat, light)
+}

--- a/src/backend/pattern/wave.ts
+++ b/src/backend/pattern/wave.ts
@@ -1,0 +1,11 @@
+import { IColorGetter } from 'src/typings'
+import { hslToRgb } from 'src/helpers'
+import { pixelsCount } from '../shared'
+
+export const getWaveColor: IColorGetter = (index, time) => {
+	const x = index / pixelsCount
+	const t = time / 1000
+	const hue = (t * 15 + x * 120) % 360
+	const light = 0.5 + 0.25 * Math.sin(x * 4 - t)
+	return hslToRgb(hue, 1, light)
+}

--- a/src/backend/telegram/settings.ts
+++ b/src/backend/telegram/settings.ts
@@ -28,10 +28,16 @@ export function selectMode(menuTemplate: MenuTemplate<Context>) {
 			[IMode.Progress]: 'progress',
 			[IMode.White]: 'white',
 			[IMode.Noise]: 'noise',
+			[IMode.Plasma]: 'plasma',
+			[IMode.Breathe]: 'breathe',
+			[IMode.Fire]: 'fire',
+			[IMode.Ocean]: 'ocean',
+			[IMode.Twilight]: 'twilight',
+			[IMode.Wave]: 'wave',
 			[IMode.Color]: 'color',
 		},
 		{
-			columns: 2,
+			columns: 4,
 			isSet: (ctx, key) => settings.mode === parseInt(key),
 			set: async (ctx, key) => {
 				settings.mode = parseInt(key)

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -12,6 +12,12 @@ export enum IMode {
 	Progress,
 	White,
 	Noise,
+	Plasma,
+	Breathe,
+	Fire,
+	Ocean,
+	Twilight,
+	Wave,
 	Color,
 }
 


### PR DESCRIPTION
## Summary
- implement Breathe, Fire, Ocean, Twilight and Wave modes
- register new modes in pattern dispatcher
- show new modes in Telegram menu and fit buttons in rows of four

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847363682b883309196a6d1b6865d86