### PR TITLE
Implement smooth transition for night and away modes

### DIFF
--- a/src/backend/night/index.ts
+++ b/src/backend/night/index.ts
@@ -9,6 +9,7 @@ import { getCurrentTime, getTargetTime, nightUpdateTimes, TargetTimes, updateDis
 export function updateNightStatus(time = getCurrentTime()) {
 	const targetSleepTime = getTargetTime(TargetTimes.sleep)
 	const targetWakeupTime = getTargetTime(TargetTimes.wakeUp)
+	const wasNight = dynamic.isNight
 	if (time >= targetSleepTime) dynamic.isNight = true
 	else if (time < targetWakeupTime) dynamic.isNight = true
 	else {
@@ -18,6 +19,8 @@ export function updateNightStatus(time = getCurrentTime()) {
 			updateKeyboard()
 		}
 	}
+
+	if (wasNight !== dynamic.isNight) dynamic.nightChanged = Date.now()
 
 	updateMessage()
 

--- a/src/backend/pattern/mappers.ts
+++ b/src/backend/pattern/mappers.ts
@@ -2,37 +2,63 @@ import { IColorGetter, IArrColor, IStaticColorGetter, IColorMapper } from 'src/t
 import { batchSize, dynamic, frameInterval, pixelsCount } from '../shared'
 import { settings } from 'src/settings'
 
+const nightDuration = 10 * 60 * 1000
+const awayDuration = 60 * 1000
+
+function mix(a: IArrColor, b: IArrColor, t: number): IArrColor {
+	return [Math.round(a[0] + (b[0] - a[0]) * t), Math.round(a[1] + (b[1] - a[1]) * t), Math.round(a[2] + (b[2] - a[2]) * t)]
+}
+
+function getOverride(now: number): { color: IArrColor; ratio: number } | undefined {
+	if (!settings.nightOverride && (dynamic.isNight || now - dynamic.nightChanged < nightDuration)) {
+		const diff = now - dynamic.nightChanged
+		const base = Math.min(1, diff / nightDuration)
+		const ratio = dynamic.isNight ? base : 1 - base
+		return { color: dynamic.disabledColor, ratio }
+	}
+	if (!settings.geoOverride && (dynamic.isAway || now - dynamic.awayChanged < awayDuration)) {
+		const diff = now - dynamic.awayChanged
+		const base = Math.min(1, diff / awayDuration)
+		const ratio = dynamic.isAway ? base : 1 - base
+		return { color: awayColor, ratio }
+	}
+}
+
 export const awayColor: IArrColor = [5, 20, 5]
 
-export const defaultMapperMiddleware = (): IArrColor | undefined => {
-	if (!settings.nightOverride && dynamic.isNight) return dynamic.disabledColor
-	if (!settings.geoOverride && dynamic.isAway) return awayColor
+export const defaultMapperMiddleware = (): { color: IArrColor; ratio: number } | undefined => {
+	const now = Date.now()
+	return getOverride(now)
 }
 
 export const callIndexedGetter = <T = never>(getter: IColorGetter<T>, onBatch?: (batchIndex: number) => T) => {
 	const now = Date.now()
+	const override = getOverride(now)
 	return Array(batchSize)
 		.fill(null)
 		.map((_, batchIndex): IArrColor[] => {
 			const batchData = onBatch && onBatch(batchIndex)
-			return Array(pixelsCount)
+			const base = Array(pixelsCount)
 				.fill(null)
 				.map((_, indexInBatch): IArrColor => getter(indexInBatch, now + batchIndex * frameInterval, batchData!))
+			if (!override) return base
+			if (override.ratio >= 1) return base.map(() => override.color)
+			return base.map(color => mix(color, override.color, override.ratio))
 		})
 }
 
 export const createIndexedMapper =
 	(getter: IColorGetter): IColorMapper =>
-	() => {
-		const middlewareRes = defaultMapperMiddleware()
-		if (middlewareRes) return [[middlewareRes]]
-		return callIndexedGetter(getter)
-	}
+	() =>
+		callIndexedGetter(getter)
 
 export const createFlatMapper =
 	(getter: IStaticColorGetter | IArrColor): IColorMapper =>
 	() => {
-		const middlewareRes = defaultMapperMiddleware()
-		const value = middlewareRes || (getter instanceof Function ? getter() : getter)
-		return [[value]]
+		const now = Date.now()
+		const override = getOverride(now)
+		const base = getter instanceof Function ? getter() : getter
+		if (!override) return [[base]]
+		if (override.ratio >= 1) return [[override.color]]
+		return [[mix(base, override.color, override.ratio)]]
 	}

--- a/src/backend/router.ts
+++ b/src/backend/router.ts
@@ -39,7 +39,9 @@ export async function phoneLastSeen() {
 		await initted
 		const devicesRes = await client.get(`/rci/show/ip/hotspot?mac=${config.routerMac}`)
 		const hosts = devicesRes.data.host as IHost[]
-		const myPhone = hosts.filter(item => item.name.includes(config.routerDevice)).sort((a, b) => (a['last-seen'] - b['last-seen']) && +Number.isInteger(a))[0]
+		const myPhone = hosts
+			.filter(item => item.name.includes(config.routerDevice))
+			.sort((a, b) => a['last-seen'] - b['last-seen'] && +Number.isInteger(a))[0]
 		return myPhone?.['last-seen']
 	} catch (err) {
 		const error = err as AxiosError
@@ -62,6 +64,7 @@ async function updatePhoneLastSeen() {
 			seenTimeout = setTimeout(() => {
 				if (!dynamic.isAway) {
 					dynamic.isAway = true
+					dynamic.awayChanged = Date.now()
 					updateMessage()
 				}
 			}, 50_000)
@@ -70,6 +73,7 @@ async function updatePhoneLastSeen() {
 		seenTimeout = null
 		if (dynamic.isAway) {
 			dynamic.isAway = false
+			dynamic.awayChanged = Date.now()
 			updateMessage()
 		}
 	}

--- a/src/backend/shared.ts
+++ b/src/backend/shared.ts
@@ -15,6 +15,8 @@ export const dynamic: IDynamicDto = {
 	isNight: true,
 	isAway: false,
 	lastMessage: 0,
+	nightChanged: Date.now(),
+	awayChanged: Date.now(),
 }
 
 export const hueToColor = (hue: number) => hsl(hue, 1, 0.5)

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -39,6 +39,8 @@ export interface IDynamicDto {
 	isNight: boolean
 	isAway: boolean
 	lastMessage: number
+	nightChanged: number
+	awayChanged: number
 	target?: Datagram.RemoteInfo
 }
 


### PR DESCRIPTION
## Summary
- gradually fade colors when night or away mode toggles
- track time of last night/away status change
- mix override color with current colors during transition

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684752f11f448330a6a0be5a2e67dd2a