### PR TITLE
feat: smooth breathe

### DIFF
--- a/src/backend/pattern/breathe.ts
+++ b/src/backend/pattern/breathe.ts
@@ -8,9 +8,10 @@ export const getBreatheColor: IColorGetter = (_, time) => {
 	const ratio = clamp(0, dynamic.overrideRatio, 1)
 
 	const freezeAt = 0.6
+	const releaseAt = 0.45
 	if (ratio >= freezeAt && dynamic.breatheHue === undefined) {
 		dynamic.breatheHue = baseHue
-	} else if (ratio < freezeAt && dynamic.breatheHue !== undefined) {
+	} else if (ratio <= releaseAt && dynamic.breatheHue !== undefined) {
 		dynamic.breatheHue = undefined
 	}
 

--- a/src/backend/pattern/breathe.ts
+++ b/src/backend/pattern/breathe.ts
@@ -5,17 +5,17 @@ import { dynamic } from '../shared'
 export const getBreatheColor: IColorGetter = (_, time) => {
 	const t = time / 1000
 	const baseHue = (t * 20) % 360
-	const baseLight = 0.5 + 0.25 * Math.sin(t / 2)
 
-	if (dynamic.overrideRatio > 0 && dynamic.breatheHue === undefined) {
+	const freezeAt = 0.6
+	if (dynamic.overrideRatio >= freezeAt && dynamic.breatheHue === undefined) {
 		dynamic.breatheHue = baseHue
-	} else if (dynamic.overrideRatio === 0 && dynamic.breatheHue !== undefined) {
+	} else if (dynamic.overrideRatio < freezeAt && dynamic.breatheHue !== undefined) {
 		dynamic.breatheHue = undefined
 	}
 
 	const hue = dynamic.breatheHue ?? baseHue
-	let amplitude = 0.25 * (1 - dynamic.overrideRatio)
-	if (dynamic.overrideRatio > 0.8) amplitude = 0
+	const ratio = Math.min(1, Math.max(0, dynamic.overrideRatio))
+	let amplitude = 0.25 * Math.sin((1 - ratio) * Math.PI * 0.5)
 	const light = 0.5 + amplitude * Math.sin(t / 2)
 	return hslToRgb(hue, 1, light)
 }

--- a/src/backend/pattern/breathe.ts
+++ b/src/backend/pattern/breathe.ts
@@ -5,17 +5,23 @@ import { dynamic } from '../shared'
 export const getBreatheColor: IColorGetter = (_, time) => {
 	const t = time / 1000
 	const baseHue = (t * 20) % 360
+	const ratio = Math.max(0, Math.min(1, dynamic.overrideRatio))
 
 	const freezeAt = 0.6
-	if (dynamic.overrideRatio >= freezeAt && dynamic.breatheHue === undefined) {
+	if (ratio >= freezeAt && dynamic.breatheHue === undefined) {
 		dynamic.breatheHue = baseHue
-	} else if (dynamic.overrideRatio < freezeAt && dynamic.breatheHue !== undefined) {
+	} else if (ratio < freezeAt && dynamic.breatheHue !== undefined) {
 		dynamic.breatheHue = undefined
 	}
 
-	const hue = dynamic.breatheHue ?? baseHue
-	const ratio = Math.min(1, Math.max(0, dynamic.overrideRatio))
-	let amplitude = 0.25 * Math.sin((1 - ratio) * Math.PI * 0.5)
+	let hue = baseHue
+	if (dynamic.breatheHue !== undefined && ratio >= freezeAt) {
+		const lockHue = dynamic.breatheHue
+		const tFreeze = (ratio - freezeAt) / (1 - freezeAt)
+		hue = lockHue * tFreeze + baseHue * (1 - tFreeze)
+	}
+
+	const amplitude = 0.25 * Math.sin((1 - ratio) * Math.PI * 0.5)
 	const light = 0.5 + amplitude * Math.sin(t / 2)
 	return hslToRgb(hue, 1, light)
 }

--- a/src/backend/pattern/breathe.ts
+++ b/src/backend/pattern/breathe.ts
@@ -1,11 +1,11 @@
 import { IColorGetter } from 'src/typings'
-import { hslToRgb } from 'src/helpers'
+import { hslToRgb, clamp, smoothStep } from 'src/helpers'
 import { dynamic } from '../shared'
 
 export const getBreatheColor: IColorGetter = (_, time) => {
 	const t = time / 1000
 	const baseHue = (t * 20) % 360
-	const ratio = Math.max(0, Math.min(1, dynamic.overrideRatio))
+	const ratio = clamp(0, dynamic.overrideRatio, 1)
 
 	const freezeAt = 0.6
 	if (ratio >= freezeAt && dynamic.breatheHue === undefined) {
@@ -14,14 +14,12 @@ export const getBreatheColor: IColorGetter = (_, time) => {
 		dynamic.breatheHue = undefined
 	}
 
-	let hue = baseHue
-	if (dynamic.breatheHue !== undefined && ratio >= freezeAt) {
-		const lockHue = dynamic.breatheHue
-		const tFreeze = (ratio - freezeAt) / (1 - freezeAt)
-		hue = lockHue * tFreeze + baseHue * (1 - tFreeze)
-	}
+	const tFreeze = smoothStep(ratio, freezeAt, 1)
+	const lockHue = dynamic.breatheHue
+	const hue = lockHue === undefined ? baseHue : lockHue * tFreeze + baseHue * (1 - tFreeze)
 
-	const amplitude = 0.25 * Math.sin((1 - ratio) * Math.PI * 0.5)
+	const baseAmp = 0.25 * Math.sin((1 - ratio) * Math.PI * 0.5)
+	const amplitude = baseAmp * (1 - tFreeze)
 	const light = 0.5 + amplitude * Math.sin(t / 2)
 	return hslToRgb(hue, 1, light)
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -16,3 +16,8 @@ export function hslToRgb(h: number, s: number, l: number): IArrColor {
 }
 
 export const clamp = (min: number, num: number, max: number) => Math.min(Math.max(num, min), max)
+
+export const smoothStep = (x: number, edge0: number, edge1: number) => {
+	const t = clamp(0, (x - edge0) / (edge1 - edge0), 1)
+	return t * t * (3 - 2 * t)
+}


### PR DESCRIPTION
## Summary
- adjust breathing pattern to smoothly freeze color on override

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6847e300095083309975245fc7e18cbd