### PR TITLE
Fix dev bot startup

### DIFF
--- a/client/src/Debug.tsx
+++ b/client/src/Debug.tsx
@@ -6,7 +6,7 @@ import { IArrColor } from '../../src/typings'
 let eventSource: EventSource
 
 export default function Debug() {
-	eventSource = eventSource ?? new EventSource('/debug/stream')
+	eventSource = eventSource ?? new EventSource('/api/debug/stream')
 
 	const [readyState, setReadyState] = useState(eventSource.readyState)
 	const pixelsRef = useRef<HTMLDivElement>(null)

--- a/src/backend/telegram/bot.ts
+++ b/src/backend/telegram/bot.ts
@@ -32,7 +32,7 @@ bot.use(async (ctx: Context, next: NextFunction) => {
 bot.use(menuMiddleware)
 
 export function startTelegram() {
-	if (import.meta.env.PROD) {
+	if (process.env.NODE_ENV !== 'test') {
 		bot.start().catch(err => console.error(err))
 	}
 }


### PR DESCRIPTION
## Summary
- start telegram bot in dev
- use `/api` prefix for debug stream

## Testing
- `pnpm test`
- `pnpm dev` *(fails: process killed)*

------
https://chatgpt.com/codex/tasks/task_e_6847f7861b2c8330b1fd636c3d67fb9e