### PR TITLE
Update README for prod note

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ After building you can serve the production build with
 npm start
 ```
 
+Run the server with `NODE_ENV=production` so that debugging routes such as
+`/debug/stream` are disabled.
+
 ## Telegram bot
 
 1. Message [@BotFather](https://t.me/BotFather) and run `/newbot`.


### PR DESCRIPTION
## Summary
- note that production should run with `NODE_ENV=production` to disable `/debug/stream`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6847fa29992c83308382f58b2075c85a