### PR TITLE
Enable effect speed in patterns

### DIFF
--- a/src/backend/pattern/breathe.ts
+++ b/src/backend/pattern/breathe.ts
@@ -1,9 +1,10 @@
 import { IColorGetter } from 'src/typings'
 import { hslToRgb } from 'src/helpers'
 import { dynamic } from '../shared'
+import { settings } from 'src/settings'
 
 export const getBreatheColor: IColorGetter = (_, time) => {
-	const t = time / 1000
+	const t = (time * settings.effectSpeed) / 1000
 	const hue = (t * 20) % 360
 	let amplitude = 0.25 * (1 - dynamic.overrideRatio)
 	if (dynamic.overrideRatio > 0.8) amplitude = 0

--- a/src/backend/pattern/noise.ts
+++ b/src/backend/pattern/noise.ts
@@ -20,7 +20,7 @@ let baseOffset = 0
 let lastTrueColor = Date.now()
 export const noiseFrameMapper: IColorMapper = () =>
 	callIndexedGetter<INoiseBatchData>(getNoiseColor, () => {
-		const rawOffset = baseOffset + 0.007
+		const rawOffset = baseOffset + 0.007 * settings.effectSpeed
 		baseOffset = rawOffset % 1
 		if (rawOffset >= 1) {
 			colors.add(toRgbLab(getNextColor()))
@@ -48,6 +48,7 @@ function getNextRandomColor() {
 }
 
 const getNoiseColor: IColorGetter<INoiseBatchData> = (index, time, batchData) => {
+	time *= settings.effectSpeed
 	const normalPosition = index / pixelsCount
 	const positionScaleNoise = 10 * normalNoise(time / 300, index) + 3
 

--- a/src/backend/pattern/noise.ts
+++ b/src/backend/pattern/noise.ts
@@ -48,7 +48,6 @@ function getNextRandomColor() {
 }
 
 const getNoiseColor: IColorGetter<INoiseBatchData> = (index, time, batchData) => {
-	time *= settings.effectSpeed
 	const normalPosition = index / pixelsCount
 	const positionScaleNoise = 10 * normalNoise(time / 300, index) + 3
 


### PR DESCRIPTION
## Summary
- apply `effectSpeed` in breathe effect
- speed up noise effect via `effectSpeed`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6848295bce60833084eea3621741262b