### PR TITLE
Add smooth mode fade

### DIFF
--- a/src/backend/pattern/index.ts
+++ b/src/backend/pattern/index.ts
@@ -10,7 +10,7 @@ import { getWaveColor } from './wave'
 import { getHeartbeatColor, getStrobeColor, getPulseColor } from './extra'
 import { createIndexedMapper, createFlatMapper } from './mappers'
 
-const transitionDuration = 2000
+const transitionDuration = 250
 
 function mix(a: IArrColor, b: IArrColor, t: number): IArrColor {
 	return [Math.round(a[0] + (b[0] - a[0]) * t), Math.round(a[1] + (b[1] - a[1]) * t), Math.round(a[2] + (b[2] - a[2]) * t)]

--- a/src/backend/pattern/index.ts
+++ b/src/backend/pattern/index.ts
@@ -10,6 +10,16 @@ import { getWaveColor } from './wave'
 import { getHeartbeatColor, getStrobeColor, getPulseColor } from './extra'
 import { createIndexedMapper, createFlatMapper } from './mappers'
 
+const transitionDuration = 2000
+
+function mix(a: IArrColor, b: IArrColor, t: number): IArrColor {
+	return [Math.round(a[0] + (b[0] - a[0]) * t), Math.round(a[1] + (b[1] - a[1]) * t), Math.round(a[2] + (b[2] - a[2]) * t)]
+}
+
+function blend(from: IArrColor[][], to: IArrColor[][], t: number): IArrColor[][] {
+	return from.map((batch, i) => batch.map((c, j) => mix(c, to[i][j], t)))
+}
+
 const mappers: Record<IMode, IColorMapper> = {
 	[IMode.Disabled]: createFlatMapper(() => dynamic.disabledColor),
 	[IMode.Rainbow]: createIndexedMapper(getRainbowColor),
@@ -26,6 +36,17 @@ const mappers: Record<IMode, IColorMapper> = {
 }
 
 export function getPixels(mode: IMode): IArrColor[][] {
+	const now = Date.now()
 	const mapper = mappers[mode]
+	if (dynamic.transition) {
+		const t = (now - dynamic.transition.start) / transitionDuration
+		if (t >= 1) {
+			dynamic.transition = undefined
+			return mapper()
+		}
+		const fromPixels = mappers[dynamic.transition.from]()
+		const toPixels = mapper()
+		return blend(fromPixels, toPixels, t)
+	}
 	return mapper()
 }

--- a/src/backend/shared.ts
+++ b/src/backend/shared.ts
@@ -19,6 +19,7 @@ export const dynamic: IDynamicDto = {
 	awayChanged: Date.now(),
 	overrideRatio: 0,
 	breatheHue: undefined,
+	transition: undefined,
 }
 
 export const hueToColor = (hue: number) => hsl(hue, 1, 0.5)

--- a/src/backend/telegram/settings.ts
+++ b/src/backend/telegram/settings.ts
@@ -2,6 +2,7 @@ import { MenuTemplate } from 'grammy-inline-menu'
 import { Context } from 'grammy'
 import { settings } from '../../settings'
 import { IMode, ISettings } from '../../typings'
+import { dynamic } from '../shared'
 import { updateKeyboard } from './updates'
 import { logger } from '../../logger'
 import { FormatStateFunction } from 'grammy-inline-menu/dist/source/buttons/select'
@@ -45,7 +46,11 @@ export function selectMode(menuTemplate: MenuTemplate<Context>) {
 			columns: 4,
 			isSet: (ctx, key) => settings.mode === parseInt(key),
 			set: async (ctx, key) => {
-				settings.mode = parseInt(key)
+				const newMode = parseInt(key)
+				if (settings.mode !== newMode) {
+					dynamic.transition = { from: settings.mode, start: Date.now() }
+					settings.mode = newMode
+				}
 				const selectedMode = IMode[settings.mode]
 				logger.info('selected mode', { selectedMode, userId: ctx.chat!.id })
 				await ctx.answerCallbackQuery(settings.mode ? `${selectedMode} mode` : 'off')

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -48,6 +48,7 @@ export interface IDynamicDto {
 	overrideRatio: number
 	breatheHue?: number
 	target?: Datagram.RemoteInfo
+	transition?: { from: IMode; start: number }
 }
 
 export interface IConfig {


### PR DESCRIPTION
## Summary
- add `transition` info to runtime state
- set transition when changing mode through Telegram
- blend pixel data between modes during active transition

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6848832a52e88330868a58d1578612d4