### PR TITLE
Add colorful pulse effects

### DIFF
--- a/src/backend/pattern/extra.ts
+++ b/src/backend/pattern/extra.ts
@@ -1,6 +1,8 @@
 import { IColorGetter, IArrColor } from 'src/typings'
 import { hslToRgb } from 'src/helpers'
 import { settings } from 'src/settings'
+import { getRainbowColor } from './rainbow'
+import { pixelsCount } from '../shared'
 
 export const getHeartbeatColor: IColorGetter = (_, time) => {
 	const cycle = 1000
@@ -51,10 +53,34 @@ export const getPulseColor: IColorGetter = (_, time) => {
 	return pulseColor.map(c => Math.round(c * intensity)) as IArrColor
 }
 
+export const getGradientPulseColor: IColorGetter = (index, time) => {
+	const base = (getRainbowColor as any)(index, time)
+	const cycle = 1000
+	const t = (time * settings.effectSpeed) % cycle
+	const intensity = Math.sin((t / cycle) * Math.PI)
+	return base.map((c: number) => Math.round(c * intensity)) as IArrColor
+}
+
+export const getMultiPulseColor: IColorGetter = (index, time) => {
+	const cycle = 1000
+	const t = (time * settings.effectSpeed) % cycle
+	if (t < lastMultiPulse) {
+		multiPulseColors = multiPulseColors.map(() => hslToRgb(Math.random() * 360, 1, 0.5))
+	}
+	lastMultiPulse = t
+	const segment = Math.min(Math.floor((index / pixelsCount) * multiPulseColors.length), multiPulseColors.length - 1)
+	const intensity = Math.sin((t / cycle) * Math.PI)
+	return multiPulseColors[segment].map((c: number) => Math.round(c * intensity)) as IArrColor
+}
+
 let strobeColor: IArrColor = [255, 255, 255]
 let lastStrobe = 0
 let pulseColor: IArrColor = [255, 0, 0]
 let lastPulse = 0
+let multiPulseColors: IArrColor[] = Array(4)
+	.fill(null)
+	.map(() => hslToRgb(Math.random() * 360, 1, 0.5))
+let lastMultiPulse = 0
 let prevHeartbeat: IArrColor = hslToRgb(Math.random() * 360, 1, 0.5)
 let nextHeartbeat: IArrColor = prevHeartbeat
 let lastHeartbeat = 0

--- a/src/backend/pattern/index.ts
+++ b/src/backend/pattern/index.ts
@@ -7,7 +7,7 @@ import { getRainbowColor } from './rainbow'
 import { getPlasmaColor } from './plasma'
 import { getBreatheColor } from './breathe'
 import { getWaveColor } from './wave'
-import { getHeartbeatColor, getStrobeColor, getPulseColor } from './extra'
+import { getHeartbeatColor, getStrobeColor, getPulseColor, getGradientPulseColor, getMultiPulseColor } from './extra'
 import { createIndexedMapper, createFlatMapper } from './mappers'
 
 const mappers: Record<IMode, IColorMapper> = {
@@ -23,6 +23,8 @@ const mappers: Record<IMode, IColorMapper> = {
 	[IMode.Heartbeat]: createIndexedMapper(getHeartbeatColor),
 	[IMode.Strobe]: createIndexedMapper(getStrobeColor),
 	[IMode.Pulse]: createIndexedMapper(getPulseColor),
+	[IMode.GradientPulse]: createIndexedMapper(getGradientPulseColor),
+	[IMode.MultiPulse]: createIndexedMapper(getMultiPulseColor),
 }
 
 export function getPixels(mode: IMode): IArrColor[][] {

--- a/src/backend/telegram/settings.ts
+++ b/src/backend/telegram/settings.ts
@@ -39,6 +39,8 @@ export function selectMode(menuTemplate: MenuTemplate<Context>) {
 			[IMode.Heartbeat]: '❤️',
 			[IMode.Strobe]: '💥',
 			[IMode.Pulse]: '🔆',
+			[IMode.GradientPulse]: '🎇',
+			[IMode.MultiPulse]: '🎆',
 		},
 		{
 			formatState,

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -23,6 +23,8 @@ export enum IMode {
 	Heartbeat,
 	Strobe,
 	Pulse,
+	GradientPulse,
+	MultiPulse,
 }
 
 export interface ISettings {


### PR DESCRIPTION
## Summary
- create `GradientPulse` and `MultiPulse` patterns
- expose the new patterns via the mapper
- add icons for the new modes in Telegram menu
- extend `IMode` enum with the new modes

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6848867947fc8330868faf6d3599d7a0