### PR TITLE
Adjust gradient pulse

### DIFF
--- a/src/backend/pattern/extra.ts
+++ b/src/backend/pattern/extra.ts
@@ -1,8 +1,7 @@
 import { IColorGetter, IArrColor } from 'src/typings'
 import { hslToRgb } from 'src/helpers'
 import { settings } from 'src/settings'
-import { getRainbowColor } from './rainbow'
-import { pixelsCount } from '../shared'
+import { pixelsCount, hueToColor } from '../shared'
 
 export const getHeartbeatColor: IColorGetter = (_, time) => {
 	const cycle = 1000
@@ -54,11 +53,14 @@ export const getPulseColor: IColorGetter = (_, time) => {
 }
 
 export const getGradientPulseColor: IColorGetter = (index, time) => {
-	const base = (getRainbowColor as any)(index, time)
+	const t = time * settings.effectSpeed
+	const hueSpan = 60
+	const hue = (t / 16 + (index / pixelsCount) * hueSpan) % 360
+	const { r, g, b } = hueToColor(hue).rgb()
 	const cycle = 1000
-	const t = (time * settings.effectSpeed) % cycle
-	const intensity = Math.sin((t / cycle) * Math.PI)
-	return base.map((c: number) => Math.round(c * intensity)) as IArrColor
+	const pulse = t % cycle
+	const intensity = Math.sin((pulse / cycle) * Math.PI)
+	return [Math.round(r * intensity), Math.round(g * intensity), Math.round(b * intensity)] as IArrColor
 }
 
 export const getMultiPulseColor: IColorGetter = (index, time) => {

--- a/tests/gradientPulse.test.ts
+++ b/tests/gradientPulse.test.ts
@@ -1,0 +1,16 @@
+import { getGradientPulseColor } from '../src/backend/pattern/extra'
+import { pixelsCount } from '../src/backend/shared'
+import { hsl, rgb } from 'd3-color'
+
+describe('getGradientPulseColor', () => {
+  test('uses partial rainbow', () => {
+    const t = 500
+    const c1 = (getGradientPulseColor as any)(0, t)
+    const c2 = (getGradientPulseColor as any)(pixelsCount - 1, t)
+    const h1 = hsl(rgb(c1[0], c1[1], c1[2])).h
+    const h2 = hsl(rgb(c2[0], c2[1], c2[2])).h
+    const diff = Math.abs(h1 - h2)
+    const d = Math.min(diff, 360 - diff)
+    expect(d).toBeLessThanOrEqual(60)
+  })
+})


### PR DESCRIPTION
## Summary
- limit gradient pulse to 60° of hue
- test gradient pulse hue span

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68488bd540c883309979c93ba1c30a43