### PR TITLE
Improve music ripple

### DIFF
--- a/src/backend/wsAudio.ts
+++ b/src/backend/wsAudio.ts
@@ -2,13 +2,22 @@ import { WebSocketServer } from 'ws'
 import fftjs from 'fft-js'
 const { fft, util } = fftjs
 
+export interface AudioEvent {
+	hue: number
+	level: number
+}
+
 export interface AudioState {
 	hue: number
 	level: number
 	freq: number
+	events: AudioEvent[]
 }
 
-export const audioState: AudioState = { hue: 0, level: 0, freq: 0 }
+export const audioState: AudioState = { hue: 0, level: 0, freq: 0, events: [] }
+
+let averages: number[] = []
+let prevAbove: boolean[] = []
 
 export function startAudioServer(port = 8081) {
 	const wss = new WebSocketServer({ port })
@@ -24,16 +33,31 @@ export function processAudio(buffer: Buffer, sampleRate = 44100) {
 	const input = Array.from(samples, s => s / 32768)
 	const spectrum = fft(input)
 	const mags = util.fftMag(spectrum)
+	const half = Math.floor(mags.length / 2)
+	if (averages.length !== half) {
+		averages = new Array(half).fill(0)
+		prevAbove = new Array(half).fill(false)
+	}
 	let max = 0
 	let idx = 0
-	for (let i = 1; i < mags.length / 2; i++) {
-		if (mags[i] > max) {
-			max = mags[i]
+	for (let i = 1; i < half; i++) {
+		const mag = mags[i]
+		averages[i] = averages[i] * 0.95 + mag * 0.05
+		const above = mag >= averages[i]
+		if (!above && prevAbove[i]) {
+			audioState.events.push({
+				hue: (i / half) * 360,
+				level: mag / half,
+			})
+		}
+		prevAbove[i] = above
+		if (mag > max) {
+			max = mag
 			idx = i
 		}
 	}
 	const freq = (idx * sampleRate) / input.length
 	audioState.freq = freq
-	audioState.hue = (idx / (mags.length / 2)) * 360
-	audioState.level = max / (mags.length / 2)
+	audioState.hue = (idx / half) * 360
+	audioState.level = max / half
 }

--- a/tests/musicRipple.test.ts
+++ b/tests/musicRipple.test.ts
@@ -5,14 +5,14 @@ beforeEach(() => {
   resetMusicRipples()
   audioState.hue = 0
   audioState.level = 0
+  audioState.events = []
 })
 
 describe('music ripple pattern', () => {
-  test('spawns ripple when level high', () => {
+  test('spawns ripple for event', () => {
     const orig = Math.random
     ;(Math as any).random = () => 0
-    audioState.level = 1
-    audioState.hue = 0
+    audioState.events.push({ hue: 0, level: 1 })
     expect((getMusicRippleColor as any)(0, 0)).toEqual([255, 0, 0])
     Math.random = orig
   })


### PR DESCRIPTION
## Summary
- spawn ripples from new audio events
- detect audio dips for ripple mode
- test for music ripple events

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6849d58a19e483308ecbf9afe1182c3d