### PR TITLE
Improve bpm sync

### DIFF
--- a/src/backend/pattern/extra.ts
+++ b/src/backend/pattern/extra.ts
@@ -7,7 +7,8 @@ import { audioState } from '../wsAudio'
 export const getHeartbeatColor: IColorGetter = (_, time) => {
 	const beat = settings.syncToMusic && audioState.bpm ? 60000 / audioState.bpm : 1000
 	const cycle = beat
-	const t = (time * settings.effectSpeed) % cycle
+	const offset = settings.syncToMusic ? audioState.beatTime : 0
+	const t = ((time - offset) * settings.effectSpeed) % cycle
 
 	if (t < lastHeartbeat) {
 		prevHeartbeat = nextHeartbeat
@@ -36,7 +37,8 @@ function pulseIntensity(t: number, offset: number, cycle: number) {
 
 export const getStrobeColor: IColorGetter = (_, time) => {
 	const interval = settings.syncToMusic && audioState.bpm ? 60000 / audioState.bpm : 200
-	const t = (time * settings.effectSpeed) % interval
+	const offset = settings.syncToMusic ? audioState.beatTime : 0
+	const t = ((time - offset) * settings.effectSpeed) % interval
 	if (t < lastStrobe) {
 		strobeColor = hslToRgb(Math.random() * 360, 1, 0.5)
 	}
@@ -47,7 +49,8 @@ export const getStrobeColor: IColorGetter = (_, time) => {
 
 export const getPulseColor: IColorGetter = (_, time) => {
 	const cycle = settings.syncToMusic && audioState.bpm ? 60000 / audioState.bpm : 1000
-	const t = (time * settings.effectSpeed) % cycle
+	const offset = settings.syncToMusic ? audioState.beatTime : 0
+	const t = ((time - offset) * settings.effectSpeed) % cycle
 	if (t < lastPulse) {
 		pulseColor = hslToRgb(Math.random() * 360, 1, 0.5)
 	}

--- a/src/backend/wsAudio.ts
+++ b/src/backend/wsAudio.ts
@@ -27,7 +27,7 @@ export function startAudioServer(port = 8081) {
 }
 
 const sampleRateDefault = 44100
-const bpmWindow = sampleRateDefault * 8
+const bpmWindow = sampleRateDefault * 12
 const sampleBuffer = new RingBuffer<number>(bpmWindow)
 let lastBpmUpdate = 0
 

--- a/tests/wsAudio.test.ts
+++ b/tests/wsAudio.test.ts
@@ -38,4 +38,11 @@ describe('processAudio', () => {
                expect(audioState.bpm).toBeLessThan(130)
        })
 
+       test('detects slow bpm', () => {
+               const buf = genBeat(80, 8, 44100)
+               processAudio(buf)
+               expect(audioState.bpm).toBeGreaterThan(70)
+               expect(audioState.bpm).toBeLessThan(90)
+       })
+
 })


### PR DESCRIPTION
## Summary
- smooth bpm calculation and estimate beat offset
- sync heartbeat, strobe and pulse to beat

## Testing
- `pnpm test:typecheck`
- `pnpm test:format`
- `pnpm test:jest`
- `pnpm test:jest --runTestsByPath tests/wsAudio.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_684aa7affe0c8330961a45b4bb8c87f4